### PR TITLE
Add loading tile animation

### DIFF
--- a/lib/presentation/screens/search_page.dart
+++ b/lib/presentation/screens/search_page.dart
@@ -61,42 +61,43 @@ class SearchPage extends HookConsumerWidget {
                 );
               },
               child: packageList.when(
-                  data: ((data) {
-                    if (searchController.text.isEmpty && data.isEmpty) {
-                      return Center(
-                        child: Text(l10n.whatAreYouLookingFor),
-                      );
-                    } else if (data.isEmpty) {
-                      return Center(
-                        child: Text(l10n.noResultsFound),
-                      );
-                    }
+                data: ((data) {
+                  if (searchController.text.isEmpty && data.isEmpty) {
+                    return Center(
+                      child: Text(l10n.whatAreYouLookingFor),
+                    );
+                  } else if (data.isEmpty) {
+                    return Center(
+                      child: Text(l10n.noResultsFound),
+                    );
+                  }
 
-                    return ListView.builder(
-                      itemCount: data.length,
-                      itemBuilder: (context, index) => RepoTile(
-                        name: data.elementAt(index).name,
-                        owner: data.elementAt(index).owner,
-                        avatarUrl: data.elementAt(index).avatarUrl,
-                        onTap: () => Navigator.push(
-                          context,
-                          MaterialPageRoute<void>(
-                            builder: (context) {
-                              return RepoDetailsPage(
-                                owner: data.elementAt(index).owner,
-                                repoName: data.elementAt(index).name,
-                              );
-                            },
-                          ),
+                  return ListView.builder(
+                    itemCount: data.length,
+                    itemBuilder: (context, index) => RepoTile(
+                      name: data.elementAt(index).name,
+                      owner: data.elementAt(index).owner,
+                      avatarUrl: data.elementAt(index).avatarUrl,
+                      onTap: () => Navigator.push(
+                        context,
+                        MaterialPageRoute<void>(
+                          builder: (context) {
+                            return RepoDetailsPage(
+                              owner: data.elementAt(index).owner,
+                              repoName: data.elementAt(index).name,
+                            );
+                          },
                         ),
                       ),
-                    );
-                  }),
-                  error: (_, __) =>
-                      Text(l10n.thereHasBeenAnErrorPullDownToRefresh),
-                  loading: () => const Center(
-                        child: CircularProgressIndicator(),
-                      )),
+                    ),
+                  );
+                }),
+                error: (_, __) =>
+                    Text(l10n.thereHasBeenAnErrorPullDownToRefresh),
+                loading: () => ListView.builder(
+                    itemCount: 10,
+                    itemBuilder: (_, __) => const LoadingRepoTile()),
+              ),
             ),
           ),
         ],

--- a/lib/presentation/widgets/repo_tile.dart
+++ b/lib/presentation/widgets/repo_tile.dart
@@ -1,5 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
 
 class RepoTile extends StatelessWidget {
   const RepoTile({
@@ -31,6 +32,47 @@ class RepoTile extends StatelessWidget {
         ),
       ),
       subtitle: Text(owner),
+    );
+  }
+}
+
+class LoadingRepoTile extends StatelessWidget {
+  const LoadingRepoTile({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final baseColor = colorScheme.onBackground.withOpacity(0.1);
+    final highlightColor = colorScheme.onBackground.withOpacity(0.2);
+
+    return ListTile(
+      leading: Shimmer.fromColors(
+        baseColor: baseColor,
+        highlightColor: highlightColor,
+        child: const CircleAvatar(),
+      ),
+      title: Shimmer.fromColors(
+        baseColor: baseColor,
+        highlightColor: highlightColor,
+        child: Container(
+          height: 20,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(15),
+            color: colorScheme.background,
+          ),
+        ),
+      ),
+      subtitle: Shimmer.fromColors(
+        baseColor: baseColor,
+        highlightColor: highlightColor,
+        child: Container(
+          height: 15,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(5),
+            color: colorScheme.background,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   flutter_localizations: 
     sdk: flutter 
   intl: any
+  shimmer: ^2.0.0
 
 dev_dependencies:
   flutter_lints: ^2.0.0


### PR DESCRIPTION
This PR adds a new LoadingListTile widget to the existing codebase that can be used as a placeholder while data is being fetched. The new widget utilizes the shimmer package to provide a subtle loading animation that mimics the look of the original ListTile. This should improve the user experience by indicating that something is happening in the background while they wait for the data to load.

<img width="448" alt="image" src="https://user-images.githubusercontent.com/13827758/229850755-1b82539d-79ba-44b0-97ba-b871967df0d7.png">
